### PR TITLE
[ADD] access_apps: `Allow install apps` implies base.group_system now…

### DIFF
--- a/access_apps/doc/changelog.rst
+++ b/access_apps/doc/changelog.rst
@@ -3,6 +3,11 @@
 Updates
 =======
 
+`1.3.0`
+-------
+
+- ADD: the "Allow install apps" group is now implies "Administration: Settings" ("base.group_system") since in Odoo 11.0 only group_system users can install apps
+
 `1.2.0`
 -------
 

--- a/access_apps/doc/changelog.rst
+++ b/access_apps/doc/changelog.rst
@@ -6,7 +6,7 @@ Updates
 `1.3.0`
 -------
 
-- ADD: the "Allow install apps" group is now implies "Administration: Settings" ("base.group_system") since in Odoo 11.0 only group_system users can install apps
+- FIX: the "Allow install apps" group is now implies "Administration: Settings" ("base.group_system") since in Odoo 11.0 only group_system users can install apps
 
 `1.2.0`
 -------

--- a/access_apps/security/access_apps_security.xml
+++ b/access_apps/security/access_apps_security.xml
@@ -13,7 +13,7 @@
     <field name="name">Allow install apps</field>
     <field name="category_id" ref="module_category_access_apps"/>
     <field name="users" eval="[(4, ref('base.user_root'))]"/>
-    <field name="implied_ids" eval="[(4, ref('group_allow_apps_only_from_settings'))]"/>
+    <field name="implied_ids" eval="[(4, ref('group_allow_apps_only_from_settings')), (4, ref('base.group_system'))]"/>
   </record>
   <record model="ir.ui.menu" id="base.menu_management">
     <field name="groups_id" eval="[(6,0, [ref('access_apps.group_allow_apps')])]"/>


### PR DESCRIPTION
… - in v11 only group_system can install apps