### PR TITLE
[FIX] Allow superuser to write groups

### DIFF
--- a/access_restricted/__openerp__.py
+++ b/access_restricted/__openerp__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Restricted administration rights',
-    'version': '11.0.1.3.3',
+    'version': '11.0.1.3.4',
     'author': 'IT-Projects LLC, Ivan Yelizariev',
     "category": "Access",
     "support": "apps@it-projects.info",

--- a/access_restricted/doc/changelog.rst
+++ b/access_restricted/doc/changelog.rst
@@ -1,6 +1,11 @@
 Updates
 =======
 
+`1.3.4`
+-------
+
+- **Fix:** Allow superuser to write groups via settings menu
+
 `1.3.3`
 -------
 

--- a/access_restricted/models/res_users.py
+++ b/access_restricted/models/res_users.py
@@ -65,7 +65,8 @@ class ResGroups(models.Model):
             # ``all(u[0] == 3 for u in users)`` is to be sure that all operations are for removing.
             # `(3, id)` tuple removes the record from the set (the Many2many field `users`)
             add_implied_group_operation = implied_group in [group[2].id for group in classified_group]
-            if users_exclude_operation or add_implied_group_operation and self.env['res.users'].has_group('access_restricted.group_allow_add_implied_from_settings'):
+            curr_user_allowed = self.env.user._is_superuser() or self.env['res.users'].has_group('access_restricted.group_allow_add_implied_from_settings')
+            if users_exclude_operation or add_implied_group_operation and curr_user_allowed:
                 self = self.sudo()
             else:
                 # do nothing with groups if there is no permission to add from settings


### PR DESCRIPTION
Superuser can added groups via app settings but the changes want be applied if he isn't member of group "Allow add implied groups from settings"