### PR TITLE
:ambulance: access_apps: admin didn't have access

### DIFF
--- a/access_apps/__openerp__.py
+++ b/access_apps/__openerp__.py
@@ -7,7 +7,7 @@
     "category": "Access",
     # "live_test_url": "",
     "images": [],
-    "version": "12.0.1.3.2",
+    "version": "12.0.1.3.3",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",

--- a/access_apps/doc/changelog.rst
+++ b/access_apps/doc/changelog.rst
@@ -1,3 +1,7 @@
+`1.3.3`
+-------
+- **Fix:** Grant `Allow installing apps` to Admin and System users (it was only System)
+
 `1.3.2`
 -------
 

--- a/access_apps/security/access_apps_security.xml
+++ b/access_apps/security/access_apps_security.xml
@@ -13,7 +13,7 @@
   <record id="group_allow_apps" model="res.groups">
     <field name="name">Allow installing apps</field>
     <field name="category_id" ref="module_category_access_apps"/>
-    <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     <field name="implied_ids" eval="[(4, ref('group_allow_apps_only_from_settings'))]"/>
   </record>
   <record model="ir.ui.menu" id="base.menu_management">


### PR DESCRIPTION
Grant `Allow installing apps` to Admin and System users (it was only System)

Partically, it broke CI tests